### PR TITLE
Removed .edu requirement for mentor profile updates

### DIFF
--- a/client/src/components/pages/Profile.js
+++ b/client/src/components/pages/Profile.js
@@ -48,8 +48,7 @@ const ProfileEditSchema = Yup.object().shape({
       is: (role) => role === "mentor",
       then: Yup.string()
         .email()
-        .matches(/.+@*.edu/i, "Mentors are required to use an .edu email.")
-        .required("Please input a valid .edu email."),
+        .required("Please input an email."),
     }),
 
   student_name: Yup.string().when("role", {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7496,9 +7496,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash-es": {
       "version": "4.17.15",


### PR DESCRIPTION
The .edu requirement should only be needed when creating an account not when updating it. 

Fixes #160 