### PR TITLE
Removes .edu requirement for updating profiles

### DIFF
--- a/client/src/components/pages/Profile.js
+++ b/client/src/components/pages/Profile.js
@@ -43,14 +43,7 @@ const ProfileEditSchema = Yup.object().shape({
   }),
   email: Yup.string()
     .email()
-    .required("Please input a valid email.")
-    .when("role", {
-      is: (role) => role === "mentor",
-      then: Yup.string()
-        .email()
-        .matches(/.+@*.edu/i, "Mentors are required to use an .edu email.")
-        .required("Please input a valid .edu email."),
-    }),
+    .required("Please input a valid email."),
 
   student_name: Yup.string().when("role", {
     is: (role) => role !== "mentor",


### PR DESCRIPTION
There are mentors who do not have a .edu address and are added manually by April I believe. If we assume that all registered mentors have a .edu email or were excepted, we don't need to check it on the profile page.